### PR TITLE
user_update_complete→トップ画面へ戻るのリンクを修正

### DIFF
--- a/shared_shop/src/main/java/jp/co/sss/shop/controller/user/UserUpdateAdminController.java
+++ b/shared_shop/src/main/java/jp/co/sss/shop/controller/user/UserUpdateAdminController.java
@@ -81,22 +81,22 @@ public class UserUpdateAdminController {
 	 * @param model  Viewとの値受渡し
 	 * @param form   会員情報フォーム
 	 * @param result 入力チェック結果
-	 * @return 
-	 * 入力値エラーあり："user/update/user_update_input_admin" 会員情報変更入力画面へ 
+	 * @return
+	 * 入力値エラーあり："user/update/user_update_input_admin" 会員情報変更入力画面へ
 	 * 入力値エラーなし："user/update/user_update_check_admin" 会員情報 変更確認画面へ
 	 */
 	@RequestMapping(path = "/user/update/check/admin", method = RequestMethod.POST)
-	public String updateCheck( Model model, @Valid @ModelAttribute UserForm form, BindingResult result) {
+	public String updateCheck(Model model, @Valid @ModelAttribute UserForm form, BindingResult result) {
 		// 入力値にエラーがあった場合、会員情報 変更入力画面表示処理に戻る
 		if (result.hasErrors()) {
-			
+
 			UserBean userBean = new UserBean();
 			// 入力値を会員情報にコピー
 			BeanUtils.copyProperties(form, userBean);
 
 			// 会員情報をViewに渡す
 			model.addAttribute("user", userBean);
-			
+
 			return "user/update/user_update_input_admin";
 		}
 
@@ -140,11 +140,13 @@ public class UserUpdateAdminController {
 			BeanUtils.copyProperties(form, userBean);
 			// 会員情報をViewに渡す
 			session.setAttribute("user", userBean);
+			//変更した会員情報をuserInfoに渡す
+			session.setAttribute("userInfo", userBean);
 		}
 
 		return "redirect:/user/update/complete/admin";
 	}
-	
+
 	/**
 	 * 会員情報変更完了画面表示
 	 *
@@ -152,7 +154,7 @@ public class UserUpdateAdminController {
 	 */
 	@RequestMapping(path = "/user/update/complete/admin", method = RequestMethod.GET)
 	public String updateCompleteRedirect() {
-		
+
 		return "user/update/user_update_complete_admin";
 	}
 

--- a/shared_shop/src/main/java/jp/co/sss/shop/controller/user/UserUpdateCustomerController.java
+++ b/shared_shop/src/main/java/jp/co/sss/shop/controller/user/UserUpdateCustomerController.java
@@ -140,6 +140,8 @@ public class UserUpdateCustomerController {
 			BeanUtils.copyProperties(form, userBean);
 			// 会員情報をViewに渡す
 			session.setAttribute("user", userBean);
+			//変更した会員情報をuserInfoに渡す
+			session.setAttribute("userInfo", userBean);
 		}
 
 		return "redirect:/user/update/complete";

--- a/shared_shop/src/main/resources/templates/user/list/user_list.html
+++ b/shared_shop/src/main/resources/templates/user/list/user_list.html
@@ -15,7 +15,7 @@
 				<th>会員氏名</th>
 				<th>メールアドレス</th>
 				<th>操作</th>
-				
+
 			</tr>
 			<tr th:each="user: ${users}">
 				<td><a th:href="@{/user/detail/admin/{id}(id=${user.id})}"
@@ -27,11 +27,19 @@
 					<input type="hidden" name="backflg" th:value="0" />
 					<input type="submit" value="変更"/>
 				</form>
-				<form method="post" th:action="@{/user/update/input/admin}" th:if="${user.authority == 0 and session.user.authority == 0}">
+
+				<form method="post" th:action="@{/user/update/input/admin}" th:if="${user.authority == 0 }">
 					<input type="hidden" name="id" th:value="${user.id}"/>
 					<input type="hidden" name="backflg" th:value="0" />
 					<input type="submit" value="変更"/>
 				</form>
+
+		<!--  <form method="post" th:action="@{/user/update/input/admin}" th:if="${user.authority == 0 and session.user.authority == 0}">
+					<input type="hidden" name="id" th:value="${user.id}"/>
+					<input type="hidden" name="backflg" th:value="0" />
+					<input type="submit" value="変更"/>
+				</form> -->
+
 				<form method="post" th:action="@{/user/delete/check/admin}" th:if="${user.authority != 0}">
 					<input type="hidden" name="id" th:value="${user.id}"/>
 					<input type="submit" value="削除" class="delete"/>

--- a/shared_shop/src/main/resources/templates/user/update/user_update_check_admin.html
+++ b/shared_shop/src/main/resources/templates/user/update/user_update_check_admin.html
@@ -34,7 +34,7 @@
 					<span class="input_title">電話番号</span>
 					<span class="input_value" th:text="${userForm.phoneNumber}"></span>
 				</li>
-				<li th:if="${session.user.authority == 1}">
+				<li th:if="${session.user.authority == 1 && userForm.authority==2}">
 					<span class="input_title">ポイント</span>
 					<span class="input_value" th:text="${userForm.point}"></span>
 				</li>

--- a/shared_shop/src/main/resources/templates/user/update/user_update_complete.html
+++ b/shared_shop/src/main/resources/templates/user/update/user_update_complete.html
@@ -9,6 +9,6 @@
 <body class="admin user_update_complete_admin">
 		<h2 class="title">会員変更完了</h2>
 		<p class="complete_message">会員情報の変更が完了しました。</p>
-		<p class="complete_link"><a th:href="@{/user/detail}">会員一覧へ戻る</a></p>
+		<p class="complete_link"><a th:href="@{/}">トップへ戻る</a></p>
 </body>
 </html>

--- a/shared_shop/src/main/resources/templates/user/update/user_update_input_admin.html
+++ b/shared_shop/src/main/resources/templates/user/update/user_update_input_admin.html
@@ -55,7 +55,7 @@
 						</label>
 
 					</li>
-					<li th:if="${session.user.authority == 1}">
+					<li th:if="${session.user.authority == 1 && user.authority==2}">
 						<label>
 							<span class="input_title">ポイント</span>
 							<input type="number" name="point" th:value="${user.point}"/>
@@ -66,7 +66,7 @@
 				<input type="hidden" name="authority" th:value="${user.authority}" />
 				<input type="hidden" name="id" th:value="${user.id}"/>
 				<input type="hidden" name="backflg" value=0 />
-				<input th:if="${session.user.authority == 0}" type="hidden" name="point" th:value="${user.point}"/>
+				<input th:if="${session.user.authority == 0 || session.user.authority==1}" type="hidden" name="point" th:value="${user.point}"/>
 				<input type="submit" value="確認" class="send_button" />
 
 			</form>


### PR DESCRIPTION
user_update_input_admin→運用管理者自身の会員変更画面からポイントの入 力フォームが出ないようにした

user_update_check_admin→運用管理者自身の変更確認画面からポイントが表示されないようにした

UserUpdateAdminController、UserUpdateCustomerController
→ヘッダに表示されるユーザー名を会員情報変更完了後、変更されるようにした